### PR TITLE
Asset bundle extraction logic

### DIFF
--- a/down_db_asset.sh
+++ b/down_db_asset.sh
@@ -14,3 +14,11 @@ unzip './arena_models/*.zip' -d './arena_models'
 rm ./arena_models/*.zip
 
 echo "Download completed!"
+
+# Extracting Asset bundles
+echo "Replacing Asset bundles in ../arena-unity/Assets/StreamingAssets/StandaloneLinux64"
+rm --recursive --force ../arena-unity/Assets/StreamingAssets/StandaloneLinux64/
+tar -xzf ./arena_models/StandaloneLinux64.tar.gz -C ../arena-unity/Assets/StreamingAssets/
+rm ./arena_models/StandaloneLinux64.tar.gz
+
+echo "Done!"


### PR DESCRIPTION
Adding logic for extracting the asset bundles into the Streaming Assets folder, the place where they can be read from inside a Unity Build.